### PR TITLE
Fix runtime crash if no build command is specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ async function run() {
 const buildAppMaybe = () => {
   const buildApp = core.getInput('build')
   if (!buildApp) {
-    return
+    return Promise.resolve()
   }
 
   debug(`building application using "${buildApp}"`)


### PR DESCRIPTION
If no build command is specified the code will crash with the following error:

/home/runner/work/_actions/joltcoke/background-server-action/test-build/webpack:/background-server-action/index.js:179
  .then(startServersMaybe)
^
TypeError: Cannot read property 'then' of undefined
    at Object.2932 (/home/runner/work/_actions/joltcoke/background-server-action/test-build/webpack:/background-server-action/index.js:179:1)
    at __nccwpck_require__ (/home/runner/work/_actions/joltcoke/background-server-action/test-build/webpack:/background-server-action/webpack/bootstrap:20:1)
    at /home/runner/work/_actions/joltcoke/background-server-action/test-build/webpack:/background-server-action/webpack/startup:4:1
    at Object.<anonymous> (/home/runner/work/_actions/joltcoke/background-server-action/test-build/dist/index.js:12010:12)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:17:47
